### PR TITLE
fix: fix wrong result returned when a lot of rows/columns

### DIFF
--- a/src/XLSXParser/Transformer/Column.php
+++ b/src/XLSXParser/Transformer/Column.php
@@ -12,16 +12,14 @@ final class Column
 {
     public function transform(string $name): int
     {
-        $number = 0;
+        $number = -1;
 
         foreach (str_split(string: $name) as $char) {
             $digit = ord(character: $char) - 65;
-
             if ($digit < 0) {
                 break;
             }
-
-            $number = $number * 26 + $digit;
+            $number = ($number + 1) * 26 + $digit;
         }
 
         return $number;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | spaghetti
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
---

Hey, I've been using your library and encountered an error in larger sheet, this seems to fix it. I guess it has something to do with default value.  
Tests are still green, but this maybe should be tested somehow in future