### PR TITLE
fix: fix incorrect read when data contains incorrect formatting

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
     backupGlobals="false"
     bootstrap="vendor/autoload.php"
     cacheResult="false"
@@ -14,9 +14,10 @@
             <directory>tests/src</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <coverage/>
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/src/XLSXParser/AbstractXMLDictionary.php
+++ b/src/XLSXParser/AbstractXMLDictionary.php
@@ -2,6 +2,10 @@
 
 namespace Spaghetti\XLSXParser;
 
+use function implode;
+use function is_array;
+use function trim;
+
 /**
  * @internal
  */
@@ -14,6 +18,10 @@ abstract class AbstractXMLDictionary extends AbstractXMLResource
     {
         while ($this->valid && !isset($this->values[$index])) {
             $this->readNext();
+        }
+
+        if (is_array(value: $this->values[$index])) {
+            return trim(string: implode(separator: ' ', array: $this->values[$index]));
         }
 
         return $this->values[$index];

--- a/src/XLSXParser/SharedStrings.php
+++ b/src/XLSXParser/SharedStrings.php
@@ -35,7 +35,7 @@ final class SharedStrings extends AbstractXMLDictionary
     {
         match ($xml->name) {
             self::INDEX => $this->currentIndex++,
-            self::VALUE => $this->values[$this->currentIndex] = trim(string: strtr($xml->readString(), ["\u{a0}" => ' ']), characters: ' '),
+            self::VALUE => $this->values[$this->currentIndex][] = trim(string: strtr($xml->readString(), ["\u{a0}" => ' ']), characters: ' '),
             default => null,
         };
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | spaghetti
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
---

Hey, I recently worked with xlsx file with a lot of incorrect and broken formatting. As I discovered, this parser did not correctly read some of the data. IDK if this is the best solution but it does work for me.

P.S. Also updated phpunit config as I was prompted by update request